### PR TITLE
fix #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firedoc",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Fire Doc, Fireball-x's JavaScript Documentation engine forked from YUI.",
   "author": "Dav Glass <davglass@gmail.com>",
   "bugs": {

--- a/themes/default/partials/method.handlebars
+++ b/themes/default/partials/method.handlebars
@@ -104,9 +104,12 @@
                 {{#params}}
                     <li class="param">
                         {{#if optional}}
-                            <code class="param-name optional">[{{name}}{{#if optdefault}}={{optdefault}}{{/if}}]</code>
+                            <code class="param-name optional">{{name}}</code>
                             <span class="type">{{#crossLink type}}{{/crossLink}}</span>
                             <span class="flag optional" title="This parameter is optional.">optional</span>
+                            {{#if optdefault}}
+                                <span>, default: {{optdefault}}</span>
+                            {{/if}}
                         {{else}}
                             <code class="param-name">{{name}}</code>
                             <span class="type">{{#crossLink type}}{{/crossLink}}</span>
@@ -125,9 +128,12 @@
                                 {{#props}}
                                 <li class="param">
                                     {{#if optional}}
-                                        <code class="param-name optional">[{{name}}{{#if optdefault}}={{optdefault}}{{/if}}]</code>
+                                        <code class="param-name optional">{{name}}</code>
                                         <span class="type">{{#crossLink type}}{{/crossLink}}</span>
                                         <span class="flag optional" title="This parameter is optional.">optional</span>
+                                        {{#if optdefault}}
+                                            <span>, default: {{optdefault}}</span>
+                                        {{/if}}
                                     {{else}}
                                         <code class="param-name">{{name}}</code>
                                         <span class="type">{{#crossLink type}}{{/crossLink}}</span>
@@ -142,9 +148,12 @@
                                             {{#props}}
                                             <li class="param">
                                                 {{#if optional}}
-                                                    <code class="param-name optional">[{{name}}{{#if optdefault}}={{optdefault}}{{/if}}]</code>
+                                                    <code class="param-name optional">{{name}}</code>
                                                     <span class="type">{{#crossLink type}}{{/crossLink}}</span>
                                                     <span class="flag optional" title="This parameter is optional.">optional</span>
+                                                    {{#if optdefault}}
+                                                        <span>, default: {{optdefault}}</span>
+                                                    {{/if}}
                                                 {{else}}
                                                     <code class="param-name">{{name}}</code>
                                                     <span class="type">{{#crossLink type}}{{/crossLink}}</span>

--- a/themes/default_zh/partials/method.handlebars
+++ b/themes/default_zh/partials/method.handlebars
@@ -104,9 +104,12 @@
                 {{#params}}
                     <li class="param">
                         {{#if optional}}
-                            <code class="param-name optional">[{{name}}{{#if optdefault}}={{optdefault}}{{/if}}]</code>
+                            <code class="param-name optional">{{name}}</code>
                             <span class="type">{{#crossLink type}}{{/crossLink}}</span>
                             <span class="flag optional" title="This parameter is optional.">optional</span>
+                            {{#if optdefault}}
+                                <span>，默认值：{{optdefault}}</span>
+                            {{/if}}
                         {{else}}
                             <code class="param-name">{{name}}</code>
                             <span class="type">{{#crossLink type}}{{/crossLink}}</span>
@@ -125,9 +128,12 @@
                                 {{#props}}
                                 <li class="param">
                                     {{#if optional}}
-                                        <code class="param-name optional">[{{name}}{{#if optdefault}}={{optdefault}}{{/if}}]</code>
+                                        <code class="param-name optional">{{name}}</code>
                                         <span class="type">{{#crossLink type}}{{/crossLink}}</span>
                                         <span class="flag optional" title="This parameter is optional.">optional</span>
+                                        {{#if optdefault}}
+                                            <span>，默认值：{{optdefault}}</span>
+                                        {{/if}}
                                     {{else}}
                                         <code class="param-name">{{name}}</code>
                                         <span class="type">{{#crossLink type}}{{/crossLink}}</span>
@@ -142,9 +148,12 @@
                                             {{#props}}
                                             <li class="param">
                                                 {{#if optional}}
-                                                    <code class="param-name optional">[{{name}}{{#if optdefault}}={{optdefault}}{{/if}}]</code>
+                                                    <code class="param-name optional">{{name}}</code>
                                                     <span class="type">{{#crossLink type}}{{/crossLink}}</span>
                                                     <span class="flag optional" title="This parameter is optional.">optional</span>
+                                                    {{#if optdefault}}
+                                                        <span>，默认值：{{optdefault}}</span>
+                                                    {{/if}}
                                                 {{else}}
                                                     <code class="param-name">{{name}}</code>
                                                     <span class="type">{{#crossLink type}}{{/crossLink}}</span>


### PR DESCRIPTION
refs: #1, this patch is to change the optional view in the following themes `default` and `default_zh` from `[cb=val] description optional` to `cb description optional, default=val` and bumped the version to `v0.8.6`.
