### PR TITLE
expose the base for template

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -596,6 +596,7 @@ var BuilderContext = {
     debug('Start writing index');
     var self = this;
     var view = new DocView(locals.meta);
+    view.base = '.';
     var html = this.render('index', view, locals);
     var filename = this.options.markdown ? '/readme.md' : '/index.html';
     var dest = this.options.dest + filename;
@@ -614,6 +615,7 @@ var BuilderContext = {
       function (file) {
         file.globals = locals.meta;
         var view = new DocView(file, null, '../');
+        view.base = '..';
         var html = self.render('file', view, locals);
         var dest = path.join(self.options.dest, 'files', file.name.replace(/\//g, '_') + self.extname);
 
@@ -652,8 +654,9 @@ var BuilderContext = {
       function (clazz) {
         clazz.globals = locals.meta;
         var view = new DocView(clazz, null, '../');
-        var html = self.render('class', view, locals);
         var dest = path.join(self.options.dest, 'classes', clazz.name + self.extname);
+        view.base = '..';
+        var html = self.render('class', view, locals);
 
         debug('Start writing class: ' + clazz.name);
         return fs.writeFileAsync(dest, html, 'utf8').then(function () {
@@ -671,8 +674,9 @@ var BuilderContext = {
       function (mod) {
         mod.globals = locals.meta;
         var view = new DocView(mod, null, '../');
-        var html = self.render('module', view, locals);
         var dest = path.join(self.options.dest, 'modules', mod.name + self.extname);
+        view.base = '..';
+        var html = self.render('module', view, locals);
 
         debug('Start writing module: ' + mod.name);
         return fs.writeFileAsync(dest, html, 'utf8').then(function () {

--- a/themes/default/partials/module.handlebars
+++ b/themes/default/partials/module.handlebars
@@ -60,7 +60,7 @@
     <ul class="index-list properties">
         {{#classes}}
         <li class="index-item">
-            <a href="{{../projectRoot}}classes/{{name}}.html">
+            <a href="{{../base}}/classes/{{name}}.html">
                 {{name}}
             </a>
         </li>

--- a/themes/default/partials/sidebar.handlebars
+++ b/themes/default/partials/sidebar.handlebars
@@ -16,14 +16,14 @@
             {{#globals.classes}}
                 <li>
                     <a class="class" href="{{project.base}}/classes/{{name}}.html">{{namespace}}</a>
-                    <a href="{{project.base}}/modules/{{module}}.html" class="api-list-item-module">@{{module}}</a>
+                    <a href="{{../base}}/modules/{{module}}.html" class="api-list-item-module">@{{module}}</a>
                 </li>
             {{/globals.classes}}
             </ul>
 
             <ul id="api-modules" class="apis modules">
             {{#globals.modules}}
-                <li><a class="module" href="{{../project.root}}/modules/{{name}}.html">{{name}}</a></li>
+                <li><a class="module" href="{{../base}}/modules/{{name}}.html">{{name}}</a></li>
             {{/globals.modules}}
             </ul>
 
@@ -31,8 +31,8 @@
             {{#globals.classes}}
                 {{#if is_enum}}
                 <li>
-                    <a class="class" href="{{../project.root}}/enums/{{name}}.html">{{name}}</a>
-                    <a href="{{../project.root}}modules/{{module}}.html" class="api-list-item-module">@{{module}}</a>
+                    <a class="class" href="{{../base}}/enums/{{name}}.html">{{name}}</a>
+                    <a href="{{../base}}/modules/{{module}}.html" class="api-list-item-module">@{{module}}</a>
                 </li>
                 {{/if}}
             {{/globals.classes}}


### PR DESCRIPTION
This fixes https://github.com/fireball-x/firedoc-theme-notab/issues/9

@nantas May I ask you to apply this patch and try to use `../base` at https://github.com/fireball-x/firedoc-theme-notab? Thanks :-)
