### PR TITLE
add --source option to output source files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The following is the helper of `firedoc-build(1)`:
     -T --theme <dir>      specify theme directory
     -D --dest <dir>       the destination folder to build
     -L --lang <language>  the i18n language
+    -S --source           whether or not output source files and show the link in 'Defined in' section.
     -v --verbose          print all verbose information
 ```
 

--- a/bin/firedoc-build.js
+++ b/bin/firedoc-build.js
@@ -13,6 +13,7 @@ program
   .option('-D --dest <dir>', 'the destination folder to build')
   .option('-L --lang <language>', 'the i18n language')
   .option('-v --verbose', 'print all verbose information')
+  .option('-S --source', 'export source files and create links.')
   .parse(process.argv);
 
 if (program.verbose) {
@@ -27,6 +28,7 @@ var doc = new Firedoc({
   http: program.http,
   dest: program.dest,
   lang: program.lang,
-  theme: program.theme
+  theme: program.theme,
+  withSrc: program.source || false
 });
 doc.build();

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -416,14 +416,19 @@ var BuilderContext = {
    * @method makeDirs
    */
   makeDirs: function (callback) {
-    var dirs = ['assets', 'classes', 'modules', 'enums', 'files'];
+    var dirs = ['assets', 'classes', 'modules', 'enums'];
+    if (this.options.withSrc) {
+      dirs.push('files');
+    }
     var root = this.options.dest || 'out';
     debug('Making default directories: ' + dirs.join(','));
     mkdirp(path.join(root, dirs[0]));
     mkdirp(path.join(root, dirs[1]));
     mkdirp(path.join(root, dirs[2]));
     mkdirp(path.join(root, dirs[3]));
-    mkdirp(path.join(root, dirs[4]));
+    if (this.options.withSrc) {
+      mkdirp(path.join(root, dirs[4]));
+    }
     return dirs;
   },
 
@@ -502,18 +507,25 @@ var BuilderContext = {
       })
       .then(function render (locals) {
         debug('Popluating files, classes, modules');
-        locals = self.populateFiles(locals);
+        if (self.options.withSrc) {
+          locals = self.populateFiles(locals);
+        }
         locals = self.populateClasses(locals);
         locals = self.populateModules(locals);
         return Promise.all(
           [
             self.writeApiMeta(locals),
             self.writeIndex(locals),
-            self.writeFiles(locals),
+            self.options.withSrc ? self.writeFiles(locals) : null,
             self.writeEnums(locals),
             self.writeClasses(locals),
             self.writeModules(locals)
-          ]
+          ].filter(function(entry, index) {
+            if (index === 2 && !self.options.withSrc) {
+              return false;
+            }
+            return true;
+          })
         );
       })
       .then(function onfinish () {
@@ -588,7 +600,7 @@ var BuilderContext = {
       'utf8'
     ).then(function () {
       self.emit('apimeta', apimeta);
-      debug('api.json finished');
+      debug('api.js finished');
     });
   },
 

--- a/lib/locals.js
+++ b/lib/locals.js
@@ -75,7 +75,9 @@ var Locals = {
     return Object.keys(self.ast.modules).map(
       function (name) {
         var mod = self.ast.modules[name];
-        mod = self.context.addFoundAt(mod);
+        if (self.options.withSrc) {
+          mod = self.context.addFoundAt(mod);
+        }
         var description = utils.localize(mod.description, self.options.lang);
         mod.description = self.parseCode(self.markdown(description));
         mod.members = mod.members || [];
@@ -95,7 +97,9 @@ var Locals = {
     return Object.keys(self.ast.classes).map(
       function (name) {
         var clazz = self.ast.classes[name];
-        clazz = self.context.addFoundAt(clazz);
+        if (self.options.withSrc) {
+          clazz = self.context.addFoundAt(clazz);
+        }
         clazz = self.appendClassToModule(clazz);
         var description = utils.localize(clazz.description, self.options.lang);
         clazz.description = self.parseCode(self.markdown(description));
@@ -298,7 +302,9 @@ var Locals = {
    */
   buildMember: function (member, forceBeMethod ,parent) {
     var self = this;
-    member = self.addFoundAt(member);
+    if (self.options.withSrc) {
+      member = self.addFoundAt(member);
+    }
     var description = utils.localize(member.description || '', this.options.lang);
     member.description = self.parseCode(self.markdown(description));
     member.hasAccessType = !!member.access;
@@ -389,7 +395,9 @@ var Locals = {
    */
   augmentData: function (o) {
     var self = this;
-    o = self.addFoundAt(o);
+    if (self.options.withSrc) {
+      o = self.addFoundAt(o);
+    }
     _.each(o, function (i, k1) {
       if (i && i.forEach) {
         _.each(i, function (a, k) {
@@ -410,7 +418,9 @@ var Locals = {
           if (a.example && !o.extendedFrom) {
             a.example = self.markdown(a.example);
           }
-          a = self.addFoundAt(a);
+          if (self.options.withSrc) {
+            a = self.addFoundAt(a);
+          }
 
           _.each(a, function (c, d) {
             if (c.forEach || (c instanceof Object)) {

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -10,7 +10,7 @@ describe('firedoc.parser', function () {
 
   describe('basic', function () {
     var src = path.join(__dirname, './targets/basic');
-    var doc = new Firedoc({'paths': [src], cwd: src});
+    var doc = new Firedoc({'paths': [src], cwd: src, withSrc: true});
     var ast, ctx;
     before(function (next) {
       doc.walk(next);


### PR DESCRIPTION
`files` folder can get really huge for a large project.
Last time I checked Fireball api docs takes up to 60mb in files folder.

So I added this option to allow developer to skip the population and links to the source file in the generated web pages. Also you can skip the option if you don't want to make your project open sourced.

This allows an option `-S --source` with `firedoc build` command, then in the theme locals you can check `this.options.withSrc` and output sources as you want.
