### PR TITLE
Example in class and module, multiple examples in one file, expand single line prop definition

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -93,6 +93,14 @@ Same as JSDoc syntax:
  */
 ```     
 
+You can also put description ahead:
+```js
+/**
+ * The local position in its parent's coordinate system
+ * @property {Vec2} position
+ */
+```
+
 ## Enum
 
 Use `@enum` with `@property` to document enum definitions.
@@ -116,7 +124,9 @@ var NumberableBool = {
 
 You can write all `@property` in the same comment block as the enum declaration.
 
-## Example Link to File
+## Examples
+
+### Example Link to File
 
 Use `@example` with `@link` to display code in a file as example.
 
@@ -128,6 +138,48 @@ Use `@example` with `@link` to display code in a file as example.
 ```
 
 The path `path/to/example.js` is based at your execution path (or cwd). 
+
+### Example File with Sections
+
+To hold multiple examples in one file, you can write your example file like this:
+
+```js
+/** @section Food */
+
+var this = 'burger';
+
+this.cook();
+
+/** @section Drink */
+
+var this = 'cola';
+```
+
+And link it to your example with `#section` notion:
+
+```js
+/**
+* @method example
+* @example {@link path/to/example.js#Food }
+*/
+```
+
+This will gives you the following example text: 
+
+```js
+var this = 'burger';
+
+this.cook();
+```
+
+### Auto Backtick Wrap
+
+Example code in a linked file or inline will be automatically wrapped in ````js` backtick. No need to add them yourself.
+
+### Example for Class and Modules
+
+Now you can write `@example` tag in class or module block.
+
 
 ## Detailed Properties of Object Parameter
 

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -184,6 +184,7 @@ var AST = {
     const len = lines.length;
     const lineHeadCharRegex = REGEX_LINE_HEAD_CHAR[this.syntaxType];
     const hasLineHeadChar = lines[0] && lineHeadCharRegex.test(lines[0]);
+    // match all tags except ignored ones
     const r = new RegExp('(?:^|\\n)\\s*((?!@' + IGNORE_TAGLIST.join(')(?!@') + ')@\\w*)');
 
     var results = [
@@ -204,7 +205,7 @@ var AST = {
     }
 
     const unidented = utils.unindent(lines.join('\n'));
-    const parts = unidented.split(r);
+    const parts = unidented.split(r); // with capturing parentheses, tags are also included in the result array
 
     var cursor = 0;
     for (; cursor < parts.length; cursor++) {
@@ -215,7 +216,7 @@ var AST = {
 
       skip = false;
       // the first token may be the description, otherwise it should be a tag
-      if (cursor === 0 && part.substr(0, 1) !== '@') {
+      if (cursor === 0 && part.substr(0, 1) !== '@') { //description ahead
         if (part) {
           tag = '@description';
           val = part;

--- a/lib/ast/digesters.js
+++ b/lib/ast/digesters.js
@@ -429,7 +429,9 @@ module.exports = {
         value = propM[2];
         target.type = propM[1];
         target.name = propM[2];
-        target.description = propM[3];
+        if (propM[3]) { // this allows in front description together with one line property and type
+          target.description = propM[3];
+        }
       }
     }
 
@@ -486,16 +488,29 @@ module.exports = {
   },
   'example': function (tagname, value, target, block) {
     if (value) {
-      var linkMatch = value.match(/\{@link (.+)\}/);
-      if (linkMatch && linkMatch.length === 2) {
+      var linkMatch = value.match(/\{@link (.+?)(?:#(.+?))*\s*\}/); // update regex to include an optional `#section` part at the end
+      if (linkMatch && linkMatch.length > 1) {
         var relative = utils.safetrim(linkMatch[1]);
         var examplePath = process.cwd() + '/' + relative;
         if (fs.existsSync(examplePath)) {
           value = fs.readFileSync(examplePath, 'utf8');
-          value = '```' + value;
+          if (!linkMatch[2]) {
+            value = '```js\n' + value + '\n```';
+          } else {
+            const r = /(\/\*+\s*@section\s*(.+?)\s*\*\/)/g;
+            const section = linkMatch[2];
+            var parts = value.split(r).filter(function(entry) {
+              if (entry === '') return false;
+              return true;
+            });
+            var index = parts.indexOf(section) + 1;
+            value = '```js\n' + parts[index].trim() + '\n```';
+          }
         } else {
           value = '```Not found for the example path: ' + relative;
         }
+      } else { //auto wrap value with backtick
+          value = '```js\n' + value.replace(/(?:^\s*```\w*\s*[\r\n]|```\s*\n*$)/g, '') + '\n```';
       }
     }
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -520,7 +520,7 @@ var BuilderContext = {
             self.writeEnums(locals),
             self.writeClasses(locals),
             self.writeModules(locals)
-          ].filter(function(entry, index) {
+          ].filter( function (entry, index) {
             if (index === 2 && !self.options.withSrc) {
               return false;
             }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -7,6 +7,7 @@
  */
 
 const _ = require('underscore');
+const Handlebars = require('handlebars');
 
 /**
  * Build file tree

--- a/lib/locals.js
+++ b/lib/locals.js
@@ -80,6 +80,14 @@ var Locals = {
         }
         var description = utils.localize(mod.description, self.options.lang);
         mod.description = self.parseCode(self.markdown(description));
+        if (mod.example) {
+          if (!_.isArray(mod.example)) {
+            mod.example = [mod.example];
+          }
+          mod.example = mod.example.map(function (v) {
+            return self.parseCode(self.markdown(v.trim()))
+          }).join('');
+        }        
         mod.members = mod.members || [];
         mod.project = self.project;
         mod.globals = self;
@@ -103,6 +111,14 @@ var Locals = {
         clazz = self.appendClassToModule(clazz);
         var description = utils.localize(clazz.description, self.options.lang);
         clazz.description = self.parseCode(self.markdown(description));
+        if (clazz.example) {
+          if (!_.isArray(clazz.example)) {
+            clazz.example = [clazz.example];
+          }
+          clazz.example = clazz.example.map(function (v) {
+            return self.parseCode(self.markdown(v.trim()))
+          }).join('');
+        }        
         clazz.members = clazz.members || [];
         clazz.project = self.project;
         clazz.globals = self;
@@ -218,7 +234,6 @@ var Locals = {
       return data;
     }
     var html = _.unescape(md.render(data || ''));
-
     //Only reprocess if helpers were asked for
     if (this.options.helpers || (html.indexOf('{{#crossLink') > -1)) {
       try {

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -360,7 +360,7 @@ describe('firedoc.parser', function () {
       assert.equal('example_optional', example1.name);
       assert.equal(true, example1.isConstructor);
       assert.deepEqual([
-        '\n```\nexample\n```'
+        '```js\nexample\n\n```'
       ], example1.example);
       assert.deepEqual([
         {
@@ -407,7 +407,7 @@ describe('firedoc.parser', function () {
       assert.equal(example2.access, 'public');
       assert.deepEqual([ 
         '```Not found for the example path: test/examples/ex0.js',
-        '```// this is an example js for test\nvar foo = bar;' 
+        '```js\n// this is an example js for test\nvar foo = bar;\n```' 
       ], example2.example);
       assert.deepEqual([
         {


### PR DESCRIPTION
fireball-x/fireball#458
- add example support for class and module
- add section specification for linked example
- support in front description for property name and type in the same line
- add auto backtick wrap for inline example.
