### PR TITLE
notab: should customize the href of logo link

### DIFF
--- a/themes/firedoc-theme-notab/layouts/main.handlebars
+++ b/themes/firedoc-theme-notab/layouts/main.handlebars
@@ -15,14 +15,15 @@
   <header class="main-header">
     <div class="content">
       <div class="project-title">
-        <a href="http://cocos.com/creator">
-          {{#if globals.project.logo}}
-          <img class="logo" src="{{@root.base}}/{{globals.project.logo}}" title="{{project.name}}">
-          {{else}}
-          <img class="logo" src="{{assets}}/img/logo.png"
-            title="Cocos Creator API">
-          {{/if}}
+        {{#if globals.project.logo}}
+        <a href="{{globals.project.logo.url}}">
+          <img class="logo" src="{{globals.project.logo.img}}" title="{{globals.project.description}}">
         </a>
+        {{else}}
+        <a href="http://cocos.com/creator">
+          <img class="logo" src="{{assets}}/img/logo.png" title="Cocos Creator API">
+        </a>
+        {{/if}}
         {{#if globals.project.name}}
           <h1 class="project-name">{{globals.project.name}}</h1>
           {{#if globals.project.version}}


### PR DESCRIPTION
Hey Because recently I'm using this awesome shared tool in my business team, but I find the href of the logo link in this template is fixed to be `http://cocos.com/creator`, so I fixed this.

@nantas please help me to review, thank you :-)
